### PR TITLE
Add support for following redirects governed by setting

### DIFF
--- a/HighlightLinksInCategory.php
+++ b/HighlightLinksInCategory.php
@@ -18,7 +18,8 @@
 class HighlightLinksInCategory {
 
     public static function onGetLinkColours( $linkcolour_ids, &$colours ) {
-	global $wgHighlightLinksInCategory;
+    global $wgHighlightLinksInCategory;
+    global $wgHighlightLinksInCategoryFollowRedirects;
 
         if ( ! count($wgHighlightLinksInCategory) ) {
             return true;
@@ -26,30 +27,83 @@ class HighlightLinksInCategory {
 
         # linkcolour_ids only contains pages that exist, which does a lot
         # of our work for us
-        $pageIDs  = array_keys($linkcolour_ids);
+        $pagesToQuery = array_keys($linkcolour_ids);
+        
+        # intermediate value that will help us construct pageToTargets
+        $nonRedirects = array_keys($linkcolour_ids);
+        
+        # associative array of page -> target. will be page -> page if
+        # link is not a redirect or if user does not want redirects followed
+        $pageToTargets = [];
+
+        $dbr = wfGetDB( DB_REPLICA );
+        
+        # follow all redirects only if the user wants to
+        if ( $wgHighlightLinksInCategoryFollowRedirects ) {
+            $res0 = $dbr->select(
+                [ 'redirect', 'page' ],
+                array('rd_from', 'page_id'),
+                $dbr->makeList( [
+                    'rd_namespace = page_namespace',
+                    'rd_title = page_title',
+                    $dbr->makeList(
+                        array('rd_from' => $pagesToQuery ), LIST_OR ),
+                   // 'rd_interwiki IS NULL',
+                ], LIST_AND )
+            );
+            foreach ( $res0 as $row ) {
+                # first, forget this page as a non-redirect
+                $nonRedirects = array_diff( $nonRedirects, [$row->rd_from] );
+                # and also as a page to query
+                $pagesToQuery = array_diff( $pagesToQuery, [$row->rd_from] );
+                
+                # then make sure we remember this association
+                $pageToTargets[$row->rd_from] = $row->page_id;
+                # and we also need to query the target id later
+                $pagesToQuery[] = $row->page_id;
+            }
+            
+        }
+        
+        # now that nonRedirects is fully populated, tell our lookup about them
+        # we can do this regardless of whether we wanted to follow redirects or not
+        # if we didn't follow redirects, this is the trivial operation of moving all
+        # pages here
+        foreach ( $nonRedirects as $nonRedirect ) {
+            $pageToTargets[$nonRedirect] = $nonRedirect;
+        }
+
         $catNames = array_keys($wgHighlightLinksInCategory);
 
         # Get page ids with appropriate categories from the DB
         # There's an index on (cl_from, cl_to) so this should be fast
-        $dbr = wfGetDB( DB_REPLICA );
-        $res = $dbr->select( 'categorylinks',
+        
+        $resultCL = $dbr->select( 'categorylinks',
             array('cl_from', 'cl_to'),
             $dbr->makeList( array(
                 $dbr->makeList(
-                    array( 'cl_from' => $pageIDs ), LIST_OR),
+                    array( 'cl_from' => $pagesToQuery ), LIST_OR),
                 $dbr->makeList(
                     array( 'cl_to'   => $catNames), LIST_OR)
                 ),
                 LIST_AND
             )
         );
-
+        
+        $classes = [];
+        foreach( $resultCL as $s ) {
+            if ( ! array_key_exists( $s->cl_from, $classes ) ) {
+                $classes[ $s->cl_from ] = '';
+            }
+            $classes[ $s->cl_from ] .= ' ' . $wgHighlightLinksInCategory[ $s->cl_to ];
+        }
+        
         # Add the color classes to each page
-        foreach ( $res as $s ) {
-            $colours[ $linkcolour_ids[ $s->cl_from ] ]
-                .= ' ' . $wgHighlightLinksInCategory[ $s->cl_to ];
+        foreach ( $pageToTargets as $page=>$target ) {
+            if ( array_key_exists( $target, $classes ) ) {
+                $colours[ $linkcolour_ids[$page] ] = $classes[ $target ];
+            }
         }
     }
 
 }
-

--- a/extension.json
+++ b/extension.json
@@ -17,7 +17,8 @@
 		]
 	},
 	"config": {
-		"HighlightLinksInCategory": { }
+		"HighlightLinksInCategory": { },
+		"HighlightLinksInCategoryFollowRedirects": false
 	},
 	"manifest_version": 1
 }


### PR DESCRIPTION
Closes #6. Add a setting $wgHighlightLinksInCategoryFollowRedirects to enable following redirects and using the targets' categories instead of the link's own categories.